### PR TITLE
template : fix for customized luci path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Luci theme for Official Openwrt and Alpha OS build ,based on bootstrap and mater
 
 </p>
 
-###FYI
+### FYI
 
-alpha os is my idea which is to develop the Indonesian OpenWrt community so that it can grow even overseas (China already has eyes), in the sense that we have to make an innovation that appears and is new, not the existing one, made our version, Mr. Sibondt once they said 'jalan ditempat komunitas indo', that's what moved my heart to make an innovation that I named alpha os (alpha = initial version, because it hasn't been perfect until now 😁)
+alpha os is my idea which is to develop the Indonesian OpenWrt community so that it can grow even overseas (China already has looking), in the sense that we have to make an innovation that appears and is new, not the existing one, made our version, Mr. Sibondt once they said 'jalan ditempat komunitas indo', that's what moved my heart to make an innovation that I named alpha os (alpha = initial version, because it hasn't been perfect until now 😁)
 
 donate
 buy me a padang rice or coffee

--- a/template/header.htm
+++ b/template/header.htm
@@ -62,15 +62,25 @@
 <header>
 	<div class="navbar active">
 		<div class="dropdown">
-			
-	<a href="/cgi-bin/luci/admin/status/overview"><img src="<%=media%>/images/house-blank.png" /></a>
- <a href="/cgi-bin/luci/admin/services/ttyd"><img src="<%=media%>/images/terminal.png" /></a>
-  <a href="/cgi-bin/luci/admin/services/openclash"><img src="<%=media%>/images/oc.png" /></a>
-  <a href="/cgi-bin/luci/admin/nas/tinyfm"><img src="<%=media%>/images/file.png" /></a>
-  <a href="/cgi-bin/luci/admin/modem/main"><img src="<%=media%>/images/chart.png" /></a>
-  <a href="/cgi-bin/luci/admin/network/network"><img src="<%=media%>/images/interfaces.png" /></a>
-
-			</div>
+			<a href="<% if luci.dispatcher.context.authsession then %><%=url('admin/status/overview')%><% else %>#<% end %>">
+			    <img src="<%=media%>/images/house-blank.png" />
+    		</a>
+    		<a href="<% if luci.dispatcher.context.authsession then %><%=url('admin/services/ttyd')%><% else %>#<% end %>">
+    		    <img src="<%=media%>/images/terminal.png" />
+    		</a>
+    		<a href="<% if luci.dispatcher.context.authsession then %><%=url('admin/services/openclash')%><% else %>#<% end %>">
+    		    <img src="<%=media%>/images/oc.png" />
+    		</a>
+    		<a href="<% if luci.dispatcher.context.authsession then %><%=url('admin/nas/tinyfm')%><% else %>#<% end %>">
+    		    <img src="<%=media%>/images/file.png" />
+    		</a>
+    		<a href="<% if luci.dispatcher.context.authsession then %><%=url('admin/modem/main')%><% else %>#<% end %>">
+    		    <img src="<%=media%>/images/chart.png" />
+    		</a>
+    		<a href="<% if luci.dispatcher.context.authsession then %><%=url('admin/network/network')%><% else %>#<% end %>">
+    		    <img src="<%=media%>/images/interfaces.png" />
+    		</a>
+		</div>
         <label class="toggler">
 			<img src="<%=media%>/gaya/icons/arrow.svg" alt="">
 		</label>
@@ -98,9 +108,9 @@
 			<img src="<%=media%>/brand.png" alt="OpenWrt">
 		</a>
 		<div class="status" id="indicators"></div>
-		<div class="logout" >  
-			<a href="/cgi-bin/luci/admin/logout" data-title="Logout">Logout</a>
-			</div>
+		<div class="logout" >
+			<a href="<% if luci.dispatcher.context.authsession then %><%=url('admin/logout')%><% else %>#<% end %>" data-title="Logout">Logout</a>
+		</div>
 		<div class="showSide">
 			<img src="<%=media%>/gaya/icons/menu_icon.svg" alt="">
 		  </div>

--- a/template/sysauth.htm
+++ b/template/sysauth.htm
@@ -39,7 +39,7 @@
     <script type="text/javascript">
         L = new LuCI({"apply_rollback":90,"resource":"\/luci-static\/resources","media":"\/luci-static\/material","documentroot":"\/www","pollinterval":5,"apply_display":1.5,"requestpath":[],"ubuspath":"\/ubus\/","scriptname":"\/cgi-bin\/luci","dispatchpath":[],"apply_timeout":5,"apply_holdoff":4,"nodespec":{"satisfied":true,"action":{"type":"template","path":"admin_status\/index"},"order":1,"depends":{"acl":["luci-mod-status-index"]},"title":"Overview"}});
     </script>
-<form method="post" action="/cgi-bin/luci"><div class="cbi-map"></div>
+<form method="post" action="<%=pcdata(luci.http.getenv("REQUEST_URI"))%>"><div class="cbi-map"></div>
 <div class='box'>
     <div class='box-form'>
       <div class='box-login-tab'></div>


### PR DESCRIPTION
I made this patch to fix a problem that occurs when you customize luci addresses (changed it from `cgi-bin/luci` to something else). People rarely customize luci paths, but it's better to fix it now.