### PR TITLE
gaya.css: fix missing minimum size setting

### DIFF
--- a/luasrc/gaya/gaya.css
+++ b/luasrc/gaya/gaya.css
@@ -2756,6 +2756,7 @@
  #cbi-firewall-zone .td,
  #cbi-network-switch_vlan .td {
  	width: 100%;
+ 	min-width: 60px;
  }
 
  .cbi-rowstyle-2 {


### PR DESCRIPTION
The lack of the “min-width” parameter when configuring luci-app-samba on a PC causes incorrect display of the fourth and fifth tables in the same row.