### PR TITLE
Fix #36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,6 @@ endef
 
 define Package/luci-theme-$(THEME_NAME)/postinst
 #!/bin/sh
-[ -n "$${IPKG_INSTROOT}" ] || {
-	( . /etc/uci-defaults/30-luci-theme-$(THEME_NAME) ) && rm -f /etc/uci-defaults/30-luci-theme-$(THEME_NAME)
-}
 endef
 
 $(eval $(call BuildPackage,luci-theme-$(THEME_NAME)))


### PR DESCRIPTION
The scripts in `/etc/uci-defaults/` will be automatically deleted after execution. Manual deletion is unnecessary.