### PR TITLE
Fix for issue #36 (Installation Error: Missing File /etc/uci-defaults/30-luci-theme-alpha During IPK Installation)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ endef
 define Package/luci-theme-$(THEME_NAME)/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-	if [ -f /etc/uci-defaults/30-luci-theme-alpha ]; then
-		. /etc/uci-defaults/30-luci-theme-alpha
-		rm -f /etc/uci-defaults/30-luci-theme-alpha
+	if [ -f /etc/uci-defaults/30-luci-theme-$(THEME_NAME) ]; then
+		. /etc/uci-defaults/30-luci-theme-$(THEME_NAME)
+		rm -f /etc/uci-defaults/30-luci-theme-$(THEME_NAME)
 	fi
 fi
 exit 0

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,13 @@ endef
 
 define Package/luci-theme-$(THEME_NAME)/postinst
 #!/bin/sh
-[ -n "$${IPKG_INSTROOT}" ] || {
-	( . /etc/uci-defaults/30-luci-theme-$(THEME_NAME) ) && rm -f /etc/uci-defaults/30-luci-theme-$(THEME_NAME)
-}
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	if [ -f /etc/uci-defaults/30-luci-theme-alpha ]; then
+		. /etc/uci-defaults/30-luci-theme-alpha
+		rm -f /etc/uci-defaults/30-luci-theme-alpha
+	fi
+fi
+exit 0
 endef
 
 $(eval $(call BuildPackage,luci-theme-$(THEME_NAME)))


### PR DESCRIPTION
To fix https://github.com/derisamedia/luci-theme-alpha/issues/36 what needs to be edited:
- postinst: Fix this by changing the new setup without causing an error when installing every OpenWRT package.