### PR TITLE
luci: update pkg_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ THEME_NAME:=alpha
 THEME_TITLE:=Alpha
 
 PKG_NAME:=luci-theme-$(THEME_NAME)
-PKG_VERSION:=3.9.5-beta
+PKG_VERSION:=3.9.5_beta
 PKG_RELEASE:=10
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
fixed openwrt build error
```
ERROR: info field 'version' has invalid value: package version is invalid
ERROR: failed to create package: package version is invalid
```